### PR TITLE
[ONNX] Add underscore to registered op names

### DIFF
--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -838,7 +838,7 @@ def _node_getitem(self, k):
 
 
 def register_custom_op_symbolic(symbolic_name, symbolic_fn, opset_version):
-    if not bool(re.match(r"^[a-zA-Z0-9-_]*::[a-zA-Z]+[a-zA-Z0-9-_]*$", symbolic_name)):
+    if not bool(re.match(r"^[a-zA-Z0-9-_]*::[a-zA-Z-_]+[a-zA-Z0-9-_]*$", symbolic_name)):
         raise RuntimeError("Failed to register operator {}. \
                            The symbolic name must match the format Domain::Name, \
                            and sould start with a letter and contain only \


### PR DESCRIPTION
This is required for rehistering torchvision::_new_empty_tensor op